### PR TITLE
added -usejavacp scala option to spark-env.sh

### DIFF
--- a/conf/spark/spark-env.sh
+++ b/conf/spark/spark-env.sh
@@ -1,4 +1,4 @@
-spark_opts="-Djava.security.krb5.conf=${KRB5_CONFIG} -Djava.security.krb5.realm=CUA.SURFSARA.NL -Djava.security.krb5.kdc=kdc.hathi.surfsara.nl"
+spark_opts="-Djava.security.krb5.conf=${KRB5_CONFIG} -Djava.security.krb5.realm=CUA.SURFSARA.NL -Djava.security.krb5.kdc=kdc.hathi.surfsara.nl -Dscala.usejavacp=true"
 
 export SPARK_SUBMIT_OPTS="${spark_opts}"
 export SPARK_HISTORY_OPTS="${spark_opts}"


### PR DESCRIPTION
This fixes this error that I was encountering while trying to run the Spark shell.

```
$ spark-shell 
16/02/19 20:15:27 INFO spark.SecurityManager: Changing view acls to: acidghost,lsde03
16/02/19 20:15:27 INFO spark.SecurityManager: Changing modify acls to: acidghost,lsde03
16/02/19 20:15:27 INFO spark.SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: Set(acidghost, lsde03); users with modify permissions: Set(acidghost, lsde03)
16/02/19 20:15:27 INFO spark.HttpServer: Starting HTTP Server
16/02/19 20:15:28 INFO server.Server: jetty-8.y.z-SNAPSHOT
16/02/19 20:15:28 INFO server.AbstractConnector: Started SocketConnector@0.0.0.0:46782
16/02/19 20:15:28 INFO util.Utils: Successfully started service 'HTTP class server' on port 46782.

Failed to initialize compiler: object scala.runtime in compiler mirror not found.
** Note that as of 2.8 scala does not assume use of the java classpath.
** For the old behavior pass -usejavacp to scala, or if using a Settings
** object programatically, settings.usejavacp.value = true.
16/02/19 20:15:28 WARN repl.SparkILoop$SparkILoopInterpreter: Warning: compiler accessed before init set up.  Assuming no postInit code.

Failed to initialize compiler: object scala.runtime in compiler mirror not found.
** Note that as of 2.8 scala does not assume use of the java classpath.
** For the old behavior pass -usejavacp to scala, or if using a Settings
** object programatically, settings.usejavacp.value = true.
Exception in thread "main" java.lang.AssertionError: assertion failed: null
	at scala.Predef$.assert(Predef.scala:179)
	at org.apache.spark.repl.SparkIMain.initializeSynchronous(SparkIMain.scala:247)
	at org.apache.spark.repl.SparkILoop$$anonfun$org$apache$spark$repl$SparkILoop$$process$1.apply$mcZ$sp(SparkILoop.scala:990)
	at org.apache.spark.repl.SparkILoop$$anonfun$org$apache$spark$repl$SparkILoop$$process$1.apply(SparkILoop.scala:945)
	at org.apache.spark.repl.SparkILoop$$anonfun$org$apache$spark$repl$SparkILoop$$process$1.apply(SparkILoop.scala:945)
	at scala.tools.nsc.util.ScalaClassLoader$.savingContextLoader(ScalaClassLoader.scala:135)
	at org.apache.spark.repl.SparkILoop.org$apache$spark$repl$SparkILoop$$process(SparkILoop.scala:945)
	at org.apache.spark.repl.SparkILoop.process(SparkILoop.scala:1059)
	at org.apache.spark.repl.Main$.main(Main.scala:31)
	at org.apache.spark.repl.Main.main(Main.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:731)
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:181)
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:206)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:121)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
16/02/19 20:15:28 INFO util.ShutdownHookManager: Shutdown hook called
16/02/19 20:15:28 INFO util.ShutdownHookManager: Deleting directory /tmp/spark-187a9765-33fb-465c-bea4-b3c32953d2f2
```

> I'm from LSDE group 3